### PR TITLE
Change the install name of flyctl to `fly`

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -4,7 +4,7 @@ set -euo pipefail
 
 GH_REPO="https://github.com/superfly/flyctl"
 TOOL_NAME="flyctl"
-TOOL_TEST="flyctl version"
+TOOL_TEST="fly version"
 
 fail() {
   echo -e "asdf-$TOOL_NAME: $*"
@@ -58,7 +58,7 @@ install_version() {
     tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
 
     mkdir -p "$install_path"/bin
-    cp "$ASDF_DOWNLOAD_PATH"/"$tool_cmd" "$install_path"/bin
+    cp "$ASDF_DOWNLOAD_PATH"/"$TOOL_NAME" "$install_path"/bin/"$tool_cmd"
 
     test -x "$install_path/bin/$tool_cmd" || fail "Expected $install_path/bin/$tool_cmd to be executable."
 


### PR DESCRIPTION
Per the README in the flyctl repo:

> Note: Most installations of `flyctl` also alias `flyctl` to `fly` as a command name and this will become the default name in the future.

https://github.com/superfly/flyctl/blob/master/README.md?plain=1#L5-L6

Alternately, I could alias them; it's up to you, if you prefer one or
the other.