### PR TITLE
Filter tags to releases with assets

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -23,7 +23,7 @@ sort_versions() {
     curl "https://api.fly.io/app/flyctl_releases/$(get_platform)/$(get_arch)/latest" |
       grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' |
       sed 's/^v//'
-    );
+  )
 
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n |
@@ -38,7 +38,7 @@ sort_versions() {
 list_github_tags() {
   git ls-remote --tags --refs "$GH_REPO" |
     grep -o 'refs/tags/.*' | cut -d/ -f3- |
-    sed 's/^v//' | # NOTE: You might want to adapt this sed to remove non-version strings from tags
+    sed 's/^v//' |                  # NOTE: You might want to adapt this sed to remove non-version strings from tags
     grep -Ev '^[0-9]{4}\.|[a-zA-Z]' # Removes tags starting with 4 digits followed by a dot and tags containing letters
 }
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -19,8 +19,20 @@ if [ -n "${GITHUB_API_TOKEN:-}" ]; then
 fi
 
 sort_versions() {
+  latest_version=$(
+    curl "https://api.fly.io/app/flyctl_releases/$(get_platform)/$(get_arch)/latest" |
+      grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' |
+      sed 's/^v//'
+    );
+
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n |
+    awk -v latest="$latest_version" '{
+      print $2
+      if ($2 == latest) {
+        exit
+      }
+    }'
 }
 
 list_github_tags() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -26,7 +26,8 @@ sort_versions() {
 list_github_tags() {
   git ls-remote --tags --refs "$GH_REPO" |
     grep -o 'refs/tags/.*' | cut -d/ -f3- |
-    sed 's/^v//' # NOTE: You might want to adapt this sed to remove non-version strings from tags
+    sed 's/^v//' | # NOTE: You might want to adapt this sed to remove non-version strings from tags
+    grep -Ev '^[0-9]{4}\.|[a-zA-Z]' # Removes tags starting with 4 digits followed by a dot and tags containing letters
 }
 
 list_all_versions() {


### PR DESCRIPTION
Fixes #7 

Looked at the tags in the flyctl repository and tried to limit to the releases only, which contain assets to download. They create lots of tags that are not "releases".

- Filter to remove any tags that include a letter or begin with 4 digits. Their releases right now are of the format `0.2.104`.
- Get the latest version from the API and after sorting, stop listing versions once the latest from the API is reached. This should guarantee there are assets to download. Currently there is a tag of `0.2.105` that matches the release version format but has no assets, is not marked as a release on Github and the API still returns `0.2.104` as the latest.
 
```sh
$ mise ls-remote flyctl
...
0.2.99
0.2.100
0.2.101
0.2.102
0.2.103
0.2.104
```